### PR TITLE
graphics: fall back to GDI when DirectDraw isn't available or failed to init

### DIFF
--- a/Graphics.h
+++ b/Graphics.h
@@ -1,5 +1,9 @@
+#ifndef GRAPHICS_H_
+#define GRAPHICS_H_
+
 #include <windows.h>
 #include <ddraw.h>
+#include <stdint.h>
 
 class Graphics
 {
@@ -12,38 +16,97 @@ public:
   };
 
   Graphics();
-  ~Graphics();
+  virtual ~Graphics();
 
-  bool Init( HINSTANCE _instance, int _width, int _height, int _zoom, WindowType _fullscreen );
-  void Update( void * _screenBuffer, int _screenWidth, int _screenHeight );
-  void HandleMessages();
-  void Close();
+  void Update(void *buffer, int width, int height);
 
-  const bool WantsToQuit() const { return mWantsToQuit; }
-  const HWND GetWindowHandle() const { return mHWnd; }
+  virtual bool Init( int _width, int _height, int _zoom, WindowType _fullscreen );
+  virtual void Close();
 
-private:
-  void Blit( void * _screenBuffer );
+  virtual void HandleMessages() = 0;
 
+  virtual const bool WantsToQuit() const = 0;
+
+protected:
+  virtual void Blit( void * _screenBuffer ) = 0;
+
+  /* fast blit function from 32-bit -> some bpp */
+  static void FastBlit(const uint32_t* vscr, void* surfacePtr, int bpp,
+    uint32_t width, uint32_t height, uint32_t noMansLandSizeInBytes);
+
+  int mPhysicalWidth;
+  int mPhysicalHeight;
+  int mIntegerZoom;
+
+  WindowType mWindowType;
+  uint32_t *mPhysicalScreen;
+};
+
+/* graphics stuff specific to Windows */
+class GraphicsWindows : public Graphics
+{
+public:
+  GraphicsWindows();
+  virtual ~GraphicsWindows();
+
+  virtual bool Init( int _width, int _height, int _zoom, WindowType _fullscreen ) override;
+  virtual void HandleMessages() override;
+  virtual void Close() override;
+
+  virtual const bool WantsToQuit() const override { return mWantsToQuit; }
+
+protected:
+  /* handled by gdi/ddraw/etc */
+  virtual void Blit( void * _screenBuffer ) = 0;
+
+  /* and now to the goodies */
   static LRESULT CALLBACK WndProcStatic( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
   LRESULT CALLBACK WndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
-
-  LPDIRECTDRAW7	mDirectDraw;
-  LPDIRECTDRAWSURFACE7 mSurfacePrimary;
-  LPDIRECTDRAWSURFACE7 mSurfaceSecondary;
-  int mBPP;
 
   RECT mRectWindow;
   RECT mRectViewport;
   RECT mRectScreen;
 
   HWND mHWnd;
-  
-  int mPhysicalWidth;
-  int mPhysicalHeight;
-  int mIntegerZoom;
 
   bool mWantsToQuit;
-  WindowType mWindowType;
-  unsigned int * mPhysicalScreen;
 };
+
+class GraphicsWindowsDDraw : public GraphicsWindows
+{
+public:
+  GraphicsWindowsDDraw();
+  virtual ~GraphicsWindowsDDraw();
+
+  virtual bool Init(int width, int height, int zoom, WindowType type) override;
+  virtual void Close() override;
+
+protected:
+  virtual void Blit(void* buffer) override;
+
+  LPDIRECTDRAW7 mDirectDraw;
+  LPDIRECTDRAWSURFACE7 mSurfacePrimary;
+  LPDIRECTDRAWSURFACE7 mSurfaceSecondary;
+  int mBPP; /* BITS per pixel */
+
+  /* needs to stay in memory for as long as graphics are open */
+  HMODULE mhDDraw;
+};
+
+class GraphicsWindowsGDI : public GraphicsWindows
+{
+public:
+  GraphicsWindowsGDI();
+  virtual ~GraphicsWindowsGDI();
+
+  virtual bool Init(int width, int height, int zoom, WindowType type) override;
+  virtual void Close() override;
+
+protected:
+  virtual void Blit(void* buffer) override;
+
+  HBITMAP mBITMAP;
+  uint32_t* mBmpBuf;
+};
+
+#endif /* GRAPHICS_H_ */

--- a/SecondRealityW32.vcxproj
+++ b/SecondRealityW32.vcxproj
@@ -37,7 +37,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -98,7 +98,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ddraw.lib;dxguid.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <YASM>
       <Debug>true</Debug>

--- a/music.c
+++ b/music.c
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include <stdio.h>
 
 unsigned char * reality_fc_data = NULL;


### PR DESCRIPTION
This separates the graphics class into different subclasses as well, with windows-specific things in one class that both GDI and directdraw inherit from, etc.

Also removes the explicit directdraw library dependency by loading it in at runtime.